### PR TITLE
Remove dead packages from apm.conf

### DIFF
--- a/apm.conf
+++ b/apm.conf
@@ -14,8 +14,6 @@ minimap
 minimap-git-diff
 project-manager
 project-switcher
-react
 theme-toggler
-travis-ci-status
 go-plus
 svg-preview


### PR DESCRIPTION
The packages "react" and "travis-ci-status" are no longer supported and will fail to install if attempted.